### PR TITLE
Avoid PHP errors if the RegEx doesn't match anything

### DIFF
--- a/Source/UserAgentParser.php
+++ b/Source/UserAgentParser.php
@@ -49,6 +49,11 @@ function parse_user_agent( $u_agent = null ) {
 
 	$key = 0;
 
+	// If nothing matched, return null (to avoid undefined index errors)
+	if (!isset($result['browser'][0]) || !isset($result['version'][0])) {
+		return null;
+	}
+
 	$data['browser'] = $result['browser'][0];
 	$data['version'] = $result['version'][0];
 


### PR DESCRIPTION
Ran into a problem where if I provide an invalid User Agent which doesn't match the RegEx, it throws undefined index 0 errors. So just added a quick check to break out if it didn't match anything.
