### PR TITLE
Added some *BSD OSes

### DIFF
--- a/Source/UserAgentParser.php
+++ b/Source/UserAgentParser.php
@@ -28,11 +28,11 @@ function parse_user_agent( $u_agent = null ) {
 	if( !$u_agent ) return $empty;
 
 	if( preg_match('/\((.*?)\)/im', $u_agent, $parent_matches) ) {
-		preg_match_all('/(?P<platform>BB\d+;|Android|CrOS|Tizen|iPhone|iPad|iPod|Linux|Macintosh|Windows(\ Phone)?|Silk|linux-gnu|BlackBerry|PlayBook|X11|(New\ )?Nintendo\ (WiiU?|3?DS)|Xbox(\ One)?)
+		preg_match_all('/(?P<platform>BB\d+;|Android|CrOS|Tizen|iPhone|iPad|iPod|Linux|FreeBSD|NetBSD|OpenBSD|Macintosh|Windows(\ Phone)?|Silk|linux-gnu|BlackBerry|PlayBook|X11|(New\ )?Nintendo\ (WiiU?|3?DS)|Xbox(\ One)?)
 				(?:\ [^;]*)?
 				(?:;|$)/imx', $parent_matches[1], $result, PREG_PATTERN_ORDER);
 
-		$priority = array( 'Xbox One', 'Xbox', 'Windows Phone', 'Tizen', 'Android', 'CrOS', 'X11' );
+		$priority = array( 'Xbox One', 'Xbox', 'Windows Phone', 'Tizen', 'Android', 'FreeBSD', 'NetBSD', 'OpenBSD', 'CrOS', 'X11' );
 
 		$result['platform'] = array_unique($result['platform']);
 		if( count($result['platform']) > 1 ) {

--- a/Tests/user_agents.json
+++ b/Tests/user_agents.json
@@ -808,5 +808,35 @@
 		"platform": null,
 		"browser": "YandexBot",
 		"version": "3.0"
+	},
+	"Mozilla\/5.0 (X11; FreeBSD amd64; rv:43.0) Gecko\/20100101 Firefox\/43.0": {
+		"platform": "FreeBSD",
+		"browser": "Firefox",
+		"version": "43.0"
+	},
+	"Mozilla\/5.0 (X11; FreeBSD amd64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/38.0.2125.104 Safari\/537.36": {
+		"platform": "FreeBSD",
+		"browser": "Chrome",
+		"version": "38.0.2125.104"
+	},
+	"Mozilla\/5.0 (X11; OpenBSD amd64; rv:43.0) Gecko\/20100101 Firefox\/43.0 SeaMonkey\/2.40": {
+		"platform": "OpenBSD",
+		"browser": "Firefox",
+		"version": "43.0"
+	},
+	"Mozilla\/5.0 (X11; OpenBSD i386) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/43.0.2357.81 Safari\/537.36": {
+		"platform": "OpenBSD",
+		"browser": "Chrome",
+		"version": "43.0.2357.81"
+	},
+	"Mozilla\/5.0 (X11; NetBSD amd64; rv:42.0) Gecko\/20100101 Firefox\/42.0": {
+		"platform": "NetBSD",
+		"browser": "Firefox",
+		"version": "42.0"
+	},
+	"Mozilla\/5.0 (X11; NetBSD i386) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/43.0.2357.124 Safari\/537.36": {
+		"platform": "NetBSD",
+		"browser": "Chrome",
+		"version": "43.0.2357.124"
 	}
 }


### PR DESCRIPTION
Hi,

I like your parser but I couldn't agree with

`if( $platform == 'linux-gnu' || $platform == 'X11' ) {
		$platform = 'Linux';
	}`

because all Unix and Unix-like OSes (still) use X11. With this patch I added most used opensource *BSDs - OpenBSD, FreeBSD and NetBSD. 
