### PR TITLE
Drops explicit Opera Next support

### DIFF
--- a/src/UserAgentParser.php
+++ b/src/UserAgentParser.php
@@ -121,7 +121,7 @@ function parse_user_agent( $u_agent = null ) {
 		$browser = $result['browser'][$key];
 		$version = $result['version'][$key];
 	} elseif( $find('OPR', $key) ) {
-		$browser = 'Opera Next';
+		$browser = 'Opera';
 		$version = $result['version'][$key];
 	} elseif( $find('Opera', $key, $browser) ) {
 		$find('Version', $key);

--- a/tests/user_agents.json
+++ b/tests/user_agents.json
@@ -329,6 +329,21 @@
 		"browser": "Opera",
 		"version": "11.61"
 	},
+	"Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.20 Safari\/537.36  OPR\/15.0.1147.18 (Edition Next)": {
+		"platform": "Macintosh",
+		"browser": "Opera",
+		"version": "15.0.1147.18"
+	},
+	"Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_8_5) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/30.0.1599.66 Safari\/537.36 OPR\/17.0.1241.36 (Edition Next)": {
+		"platform": "Macintosh",
+		"browser": "Opera",
+		"version": "17.0.1241.36"
+	},
+	"Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/79.0.3945.117 Safari\/537.36 OPR\/66.0.3515.36": {
+		"platform": "Macintosh",
+		"browser": "Opera",
+		"version": "66.0.3515.36"
+	},
 	"Mozilla\/4.0 (compatible; MSIE 8.0; Windows NT 6.1; de) Opera 11.01": {
 		"platform": "Windows",
 		"browser": "Opera",
@@ -353,16 +368,6 @@
 		"platform": "Windows",
 		"browser": "Opera",
 		"version": "11.10"
-	},
-	"Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.20 Safari\/537.36  OPR\/15.0.1147.18 (Edition Next)": {
-		"platform": "Macintosh",
-		"browser": "Opera Next",
-		"version": "15.0.1147.18"
-	},
-	"Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_8_5) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/30.0.1599.66 Safari\/537.36 OPR\/17.0.1241.36 (Edition Next)": {
-		"platform": "Macintosh",
-		"browser": "Opera Next",
-		"version": "17.0.1241.36"
 	},
 	"Mozilla\/5.0 (Macintosh; U; PPC Mac OS X 10_4_11; en) AppleWebKit\/531.22.7 (KHTML, like Gecko) Version\/4.0.5 Safari\/531.22.7": {
 		"platform": "Macintosh",


### PR DESCRIPTION
Opera Next hasn't really _been a thing_ since seemingly 2014, and current versions of Opera are being misidentified as Opera Next (see: #60)

This change removes explicit differentiation of Opera and Opera Next.